### PR TITLE
Fix bug when headers in different tabs have different margin-tops

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -116,3 +116,7 @@ div.content-container {
         margin-bottom: 0 !important;
     }
 }
+
+.block-language-tabs :is(p,pre,table,ul,ol) + :is(h1,h2,h3,h4,h5,h6) {
+    margin-top: var(--heading-spacing);
+}


### PR DESCRIPTION
## Problem visualisation

### Tab 1
![image](https://github.com/user-attachments/assets/5663d3af-8350-4742-b72f-9c99c686d398)

### Tab 2
![image](https://github.com/user-attachments/assets/7b6ca5ce-0fe0-4000-9849-44c8cb1fe7bf)

### Outside of tabs
![image](https://github.com/user-attachments/assets/818e6350-652b-465d-8ff3-436cdd54dbb2)

## Problem description

The problem is in this default CSS rule:

```css
.markdown-rendered div:has( > :is(p,pre,table,ul,ol)) + div > :is(h1,h2,h3,h4,h5,h6) {
margin-top: var(--heading-spacing)
}
```
In general case headers are inside `div`s. And if before a `div` with a header there is another `div` with a `p` tag, than this header gets `var(--heading-spacing)`. In case of tabs headers follow `p` tags directly. Thy are not in different `div`s, but in the same `div`. So this rule is not applicable.

## Solution

Just added a CSS rule that adapts the default rule (above) for application inside tabs:

```css
.block-language-tabs :is(p,pre,table,ul,ol) + :is(h1,h2,h3,h4,h5,h6) {
    margin-top: var(--heading-spacing);
}
```

## Markdown to test

~~~tabs
--- Tab 1
# Header 1

Some text

# Header 2

Some text

--- Tab 2
# Header 1

Some text

# Header 2

Some text
~~~

I tested it a bit (not very much) and it seems it doesn't break anything, but I can't guarantee that for sure.